### PR TITLE
commit

### DIFF
--- a/src/main/java/com/example/bookclub/book/ApiResponse.java
+++ b/src/main/java/com/example/bookclub/book/ApiResponse.java
@@ -1,0 +1,46 @@
+package com.example.bookclub.book;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+public class ApiResponse<T> {
+
+    private static final String SUCCESS_STATUS = "success";
+    private static final String ERROR_STATUS = "error";
+    private String status;
+    private String message;
+    private T data;
+    @JsonInclude(JsonInclude.Include.NON_NULL) // count 필드가 null인 경우 직렬화에서 제외
+    private Integer count;
+
+    public ApiResponse(String status,String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public ApiResponse(String status, T data, Integer count) {
+        this.status = status;
+        this.data = data;
+        this.count = count;
+    }
+
+    // 응답 데이터가 하나일 경우
+    public static <T> ApiResponse<T> createSuccess(String message, T data) {
+        return new ApiResponse<>(SUCCESS_STATUS, message, data);
+    }
+
+    // 응답 데이터가 여러개일 경우
+    public static <T> ApiResponse<T> createSuccess(T data, Integer count) {
+        return new ApiResponse<>(SUCCESS_STATUS, data, count);
+    }
+
+    // 요청 에러
+    public static ApiResponse<?> createError(String message) {
+        return new ApiResponse<>(ERROR_STATUS, message, (Object) null);
+    }
+
+
+}

--- a/src/main/java/com/example/bookclub/book/BaseTimeEntity.java
+++ b/src/main/java/com/example/bookclub/book/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.example.bookclub.book;
+
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public class BaseTimeEntity {
+
+    @CreationTimestamp
+    private LocalDateTime createdDate;
+    @UpdateTimestamp
+    private LocalDateTime updatedDate;
+}

--- a/src/main/java/com/example/bookclub/book/Book.java
+++ b/src/main/java/com/example/bookclub/book/Book.java
@@ -1,0 +1,92 @@
+package com.example.bookclub.book;
+
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Book extends BaseTimeEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false, length = 20)
+    private String author;
+
+    @Column(length = 20)
+    private String translator;
+
+    @Column(nullable = false, length = 20)
+    private String publisher;
+
+    @Column(nullable = false)
+    private LocalDate publicationDate;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(columnDefinition = "TEXT")
+    private String contents;
+
+    @Column(nullable = false, length = 300)
+    private String coverImageUrl;
+
+    @Column(nullable = false, unique = true)
+    private Long isbn;
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Builder
+    public Book(Long id, String title, String author,
+                String translator, String publisher, LocalDate publicationDate,
+                String description, String contents, String coverImageUrl, Long isbn) {
+        this.id = id;
+        this.title = title;
+        this.author = author;
+        this.translator = translator;
+        this.publisher = publisher;
+        this.publicationDate = publicationDate;
+        this.description = description;
+        this.contents = contents;
+        this.coverImageUrl = coverImageUrl;
+        this.isbn = isbn;
+    }
+
+    public void update(BookRequestDto requestDto) {
+        if (requestDto.getTitle() != null) {
+            this.title = requestDto.getTitle();
+        }
+        if (requestDto.getAuthor() != null) {
+            this.author = requestDto.getAuthor();
+        }
+        if (requestDto.getTranslator() != null) {
+            this.translator = requestDto.getTranslator();
+        }
+        if (requestDto.getPublisher() != null) {
+            this.publisher = requestDto.getPublisher();
+        }
+        if (requestDto.getPublicationDate() != null) {
+            this.publicationDate = requestDto.getPublicationDate();
+        }
+        if (requestDto.getDescription() != null) {
+            this.description = requestDto.getDescription();
+        }
+        if (requestDto.getContents() != null) {
+            this.contents = requestDto.getContents();
+        }
+        if (requestDto.getCoverImageUrl() != null) {
+            this.coverImageUrl = requestDto.getCoverImageUrl();
+        }
+    }
+}
+

--- a/src/main/java/com/example/bookclub/book/BookController.java
+++ b/src/main/java/com/example/bookclub/book/BookController.java
@@ -1,0 +1,88 @@
+package com.example.bookclub.book;
+
+
+import com.example.bookclub.exception.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+import java.util.List;
+
+@RestController
+public class BookController {
+
+    private final BookService bookService;
+
+    public BookController(BookService bookService) {
+        this.bookService = bookService;
+    }
+
+    // 상품 등록
+    @PostMapping("/books")
+    public ResponseEntity<ApiResponse<Long>> registerBook(@RequestBody BookRequestDto requestDto) {
+        Long id = bookService.registerBook(requestDto);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.createSuccess("등록되었습니다", id));
+    }
+
+    // 도서 조회
+    @GetMapping("/books/{bookId}")
+    public ResponseEntity<ApiResponse<BookResponseDto>> getBook(@PathVariable Long bookId) {
+        BookResponseDto responseDto = bookService.getBook(bookId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.createSuccess(null, responseDto));
+    }
+
+    // 도서 삭제
+    @DeleteMapping("/books/{bookId}")
+    public ResponseEntity<ApiResponse<Long>> deleteBook(@PathVariable Long bookId) {
+        bookService.deleteBook(bookId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.createSuccess("삭제되었습니다", bookId));
+
+    }
+
+    // 도서 수정
+    @PatchMapping("/books/{bookId}")
+    public ResponseEntity<ApiResponse<Long>> updateBook(@PathVariable Long bookId, @RequestBody BookRequestDto requestDto) {
+        Long id = bookService.updateBook(bookId, requestDto);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.createSuccess("수정되었습니다", id));
+    }
+
+    // 신간 도서 조회
+    @GetMapping("/books/new")
+    public ResponseEntity<ApiResponse<List<BookSearchResultDto>>> searchNewBooks() {
+        List<BookSearchResultDto> newBooks = bookService.searchNewBooks();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.createSuccess(newBooks, newBooks.size()));
+
+    }
+
+    // 도서 검색
+    @GetMapping("/books/search")
+    public ResponseEntity<ApiResponse<List<BookSearchResultDto>>> searchBooks(@RequestParam String keyword) {
+        List<BookSearchResultDto> newBooks = bookService.searchBooks(keyword);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.createSuccess(newBooks, newBooks.size()));
+
+
+    }
+}

--- a/src/main/java/com/example/bookclub/book/BookRepository.java
+++ b/src/main/java/com/example/bookclub/book/BookRepository.java
@@ -1,0 +1,19 @@
+package com.example.bookclub.book;
+
+import com.example.bookclub.book.Book;
+
+<<<<<<< HEAD
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface BookRepository {
+
+    Book save(Book book); // 도서 등록
+    Optional<Book> findById(Long bookId); // 도서 단건 조회
+    void delete(Book book); // 도서 단건 삭제
+    List<Book> findByNewBooks(LocalDate startDate, LocalDate endDate); // 신간 도서 조회
+    List<Book> findByKeyword(String keyword); // 도서 검색 조회
+    Book findByIsbn(Long isbn); // isbn 중복 검사
+
+}

--- a/src/main/java/com/example/bookclub/book/BookRequestDto.java
+++ b/src/main/java/com/example/bookclub/book/BookRequestDto.java
@@ -1,0 +1,48 @@
+package com.example.bookclub.book;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class BookRequestDto {
+    private String title;
+    private String author;
+    private String translator;
+    private String publisher;
+    private LocalDate publicationDate;
+    private String description;
+    private String contents;
+    private String coverImageUrl;
+    private Long isbn;
+
+    @Builder
+    public BookRequestDto(String title, String author, String translator,
+                          String publisher, LocalDate publicationDate,
+                          String description, String contents, String coverImageUrl, Long isbn) {
+        this.title = title;
+        this.author = author;
+        this.translator = translator;
+        this.publisher = publisher;
+        this.publicationDate = publicationDate;
+        this.description = description;
+        this.contents = contents;
+        this.coverImageUrl = coverImageUrl;
+        this.isbn = isbn;
+    }
+
+    public Book toEntity() {
+        return Book.builder()
+                .title(title)
+                .author(author)
+                .translator(translator)
+                .publisher(publisher)
+                .publicationDate(publicationDate)
+                .description(description)
+                .contents(contents)
+                .coverImageUrl(coverImageUrl)
+                .isbn(isbn)
+                .build();
+    }
+}

--- a/src/main/java/com/example/bookclub/book/BookResponseDto.java
+++ b/src/main/java/com/example/bookclub/book/BookResponseDto.java
@@ -1,0 +1,38 @@
+package com.example.bookclub.book;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class BookResponseDto {
+    private Long id;
+    private String title;
+    private String author;
+    private String translator;
+    private String publisher;
+    private LocalDate publicationDate;
+    private String description;
+    private String contents;
+    private String coverImageUrl;
+    private Long isbn;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+
+    public BookResponseDto(Book entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.author = entity.getAuthor();
+        this.translator = entity.getTranslator();
+        this.publisher = entity.getPublisher();
+        this.publicationDate = entity.getPublicationDate();
+        this.description = entity.getDescription();
+        this.contents = entity.getContents();
+        this.coverImageUrl = entity.getCoverImageUrl();
+        this.isbn = entity.getIsbn();
+        this.createdDate = entity.getCreatedDate();
+        this.updatedDate = entity.getUpdatedDate();
+    }
+
+}

--- a/src/main/java/com/example/bookclub/book/BookSearchResultDto.java
+++ b/src/main/java/com/example/bookclub/book/BookSearchResultDto.java
@@ -1,0 +1,22 @@
+package com.example.bookclub.book;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BookSearchResultDto {
+    private String title;
+    private String author;
+    private String translator;
+    private String publisher;
+    private String coverImageUrl;
+
+    @Builder
+    public BookSearchResultDto(String title, String author, String translator, String publisher, String coverImageUrl) {
+        this.title = title;
+        this.author = author;
+        this.translator = translator;
+        this.publisher = publisher;
+        this.coverImageUrl = coverImageUrl;
+    }
+}

--- a/src/main/java/com/example/bookclub/book/BookService.java
+++ b/src/main/java/com/example/bookclub/book/BookService.java
@@ -1,0 +1,101 @@
+package com.example.bookclub.book;
+
+import com.example.bookclub.book.BookRequestDto;
+import com.example.bookclub.book.BookResponseDto;
+import com.example.bookclub.book.BookSearchResultDto;
+import com.example.bookclub.book.Book;
+import com.example.bookclub.book.BookRepository;
+import com.example.bookclub.exception.DuplicateBookException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Slf4j
+@Service
+public class BookService {
+
+    private final BookRepository bookRepository;
+
+    public BookService(BookRepository bookRepository) {
+        this.bookRepository = bookRepository;
+    }
+
+    // 등록 로직
+    public Long registerBook(BookRequestDto requestDto) {
+        if (bookRepository.findByIsbn(requestDto.getIsbn()) != null) {
+            throw new DuplicateBookException("이미 존재하는 isbn 번호입니다.");
+        }
+
+        return bookRepository.save(requestDto.toEntity()).getId();
+    }
+
+
+    // 단건 조회 로직
+    public BookResponseDto getBook(Long bookId) {
+        Book book = findByIdOrThrow(bookId);
+
+        return new BookResponseDto(book);
+    }
+
+    // 삭제 로직
+    public void deleteBook(Long bookId) {
+        Book book = findByIdOrThrow(bookId);
+
+        bookRepository.delete(book);
+    }
+
+    // 수정 로직
+    public Long updateBook(Long bookId, BookRequestDto requestDto) {
+        Book book = findByIdOrThrow(bookId);
+        book.update(requestDto);
+        bookRepository.save(book);
+
+        return bookId;
+    }
+
+    // 도서 존재 유무 확인 처리
+    private Book findByIdOrThrow(Long bookId) {
+        Book book = bookRepository.findById(bookId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 책입니다."));
+
+        return book;
+    }
+
+    // 신간 도서 조회 로직
+    public List<BookSearchResultDto> searchNewBooks() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusMonths(1);
+        List<Book> findBooks = bookRepository.findByNewBooks(startDate, endDate);
+        List<BookSearchResultDto> dtos = entityToDtos(findBooks);
+
+        return dtos;
+    }
+
+    // 도서 검색 조회
+    public List<BookSearchResultDto> searchBooks(String keyword) {
+        List<Book> findBooks = bookRepository.findByKeyword(keyword);
+        List<BookSearchResultDto> dtos = entityToDtos(findBooks);
+
+        return dtos;
+    }
+
+    //entity -> dto
+    private static List<BookSearchResultDto> entityToDtos(List<Book> findBooks) {
+        List<BookSearchResultDto> dtos = new ArrayList<>();
+        for (Book book : findBooks) {
+            BookSearchResultDto dto = BookSearchResultDto.builder()
+                    .title(book.getTitle())
+                    .author(book.getAuthor())
+                    .translator(book.getTranslator())
+                    .publisher(book.getPublisher())
+                    .coverImageUrl(book.getCoverImageUrl())
+                    .build();
+
+            dtos.add(dto);
+        }
+
+        return dtos;
+    }
+}

--- a/src/main/java/com/example/bookclub/book/DuplicateBookException.java
+++ b/src/main/java/com/example/bookclub/book/DuplicateBookException.java
@@ -1,0 +1,12 @@
+package com.example.bookclub.book;
+
+public class DuplicateBookException extends RuntimeException{
+    public DuplicateBookException() {
+        super();
+    }
+
+    public DuplicateBookException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/example/bookclub/book/ExceptionAdvice.java
+++ b/src/main/java/com/example/bookclub/book/ExceptionAdvice.java
@@ -1,0 +1,24 @@
+package com.example.bookclub.book;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(DuplicateBookException.class)
+    public ResponseEntity<ApiResponse<?>>  duplicateBookExceptionHandle(DuplicateBookException  e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.createError(e.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>>  IllegalArgumentExceptionHandle(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.createError(e.getMessage()));
+    }
+}

--- a/src/main/java/com/example/bookclub/book/JpaBookRepository.java
+++ b/src/main/java/com/example/bookclub/book/JpaBookRepository.java
@@ -1,0 +1,24 @@
+package com.example.bookclub.book;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+
+@Repository
+public interface JpaBookRepository extends JpaRepository<Book, Long>, BookRepository {
+
+    @Override
+    @Query("SELECT b FROM Book b WHERE b.publicationDate BETWEEN :startDate AND :endDate")
+    List<Book> findByNewBooks(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Override
+    //@Query("SELECT b FROM book b WHERE b.title LIKE %:keyword% OR b.author LIKE %:keyword% OR b.translator LIKE %:keyword%")
+    @Query("SELECT b FROM Book b WHERE b.title LIKE CONCAT('%', :keyword, '%') OR b.author LIKE CONCAT('%', :keyword, '%') OR b.translator LIKE CONCAT('%', :keyword, '%')")
+    List<Book> findByKeyword(@Param("keyword") String keyword);
+
+}

--- a/src/main/java/com/example/bookclub/book/MapBookRepository.java
+++ b/src/main/java/com/example/bookclub/book/MapBookRepository.java
@@ -1,0 +1,76 @@
+package com.example.bookclub.book;
+
+import java.time.LocalDate;
+import java.util.*;
+
+//@Repository
+//@Primary
+public class MapBookRepository implements BookRepository{
+    private static final Map<Long, Book> db = new HashMap<>();
+    private static Long sequence = 0L;
+
+    @Override
+    public Book save(Book book) {
+        if (book.getId() == null) {
+            book.setId(++sequence);
+        }
+        db.put(book.getId(), book);
+        return db.get(book.getId());
+    }
+
+    @Override
+    public Optional<Book> findById(Long bookId) {
+        return Optional.ofNullable(db.get(bookId));
+    }
+
+    @Override
+    public void delete(Book book) {
+        db.remove(book.getId());
+    }
+
+    @Override
+    public List<Book> findByNewBooks(LocalDate startDate, LocalDate endDate) {
+        List<Book> findBooks = new ArrayList<>();
+
+        for (Long key : db.keySet()) {
+            LocalDate publicationDate = db.get(key).getPublicationDate();
+
+            if (publicationDate.isAfter(startDate) && publicationDate.isBefore(endDate)) {
+                findBooks.add(db.get(key));
+            }
+        }
+
+        return findBooks;
+    }
+
+    @Override
+    public List<Book> findByKeyword(String keyword) {
+        List<Book> findBooks = new ArrayList<>();
+
+        for (Long key : db.keySet()) {
+            String title = db.get(key).getTitle();
+            String author = db.get(key).getAuthor();
+            String translator = db.get(key).getTranslator();
+
+            if (title.contains(keyword) || author.contains(keyword) || translator.contains(keyword)) {
+                findBooks.add(db.get(key));
+            }
+        }
+
+        return findBooks;
+    }
+
+    @Override
+    public Book findByIsbn(Long isbn) {
+        for (Long key : db.keySet()) {
+            Long title = db.get(key).getIsbn();
+
+            if (title.equals(isbn)) {
+                return db.get(key);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/bookclub/exception/ApiResponse.java
+++ b/src/main/java/com/example/bookclub/exception/ApiResponse.java
@@ -1,0 +1,47 @@
+package com.example.bookclub.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+public class ApiResponse<T> {
+
+    private static final String SUCCESS_STATUS = "success";
+    private static final String ERROR_STATUS = "error";
+    private String status;
+    private String message;
+    private T data;
+    @JsonInclude(JsonInclude.Include.NON_NULL) // count 필드가 null인 경우 직렬화에서 제외
+    private Integer count;
+
+    public ApiResponse(String status,String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public ApiResponse(String status, T data, Integer count) {
+        this.status = status;
+        this.data = data;
+        this.count = count;
+    }
+
+    // 응답 데이터가 하나일 경우
+    public static <T> ApiResponse<T> createSuccess(String message, T data) {
+        return new ApiResponse<>(SUCCESS_STATUS, message, data);
+    }
+
+    // 응답 데이터가 여러개일 경우
+    public static <T> ApiResponse<T> createSuccess(T data, Integer count) {
+        return new ApiResponse<>(SUCCESS_STATUS, data, count);
+    }
+
+    // 요청 에러
+    public static ApiResponse<?> createError(String message) {
+        return new ApiResponse<>(ERROR_STATUS, message, (Object) null);
+    }
+
+
+}

--- a/src/main/java/com/example/bookclub/exception/DuplicateBookException.java
+++ b/src/main/java/com/example/bookclub/exception/DuplicateBookException.java
@@ -1,0 +1,12 @@
+package com.example.bookclub.exception;
+
+public class DuplicateBookException extends RuntimeException{
+    public DuplicateBookException() {
+        super();
+    }
+
+    public DuplicateBookException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/example/bookclub/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/bookclub/exception/ExceptionAdvice.java
@@ -1,0 +1,24 @@
+package com.example.bookclub.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(DuplicateBookException.class)
+    public ResponseEntity<ApiResponse<?>>  duplicateBookExceptionHandle(DuplicateBookException  e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.createError(e.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>>  IllegalArgumentExceptionHandle(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.createError(e.getMessage()));
+    }
+}

--- a/src/test/java/com/example/bookclub/book/BookRepositoryTest.java
+++ b/src/test/java/com/example/bookclub/book/BookRepositoryTest.java
@@ -1,0 +1,148 @@
+package com.example.bookclub.book;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+@Transactional
+@SpringBootTest
+public class BookRepositoryTest {
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Test
+    public void 도서_등록() {
+        // Given
+        String expectedTitle = "속죄";
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .title(expectedTitle)
+                .author("이언 매큐언")
+                .translator("한정아")
+                .publisher("문학동네")
+                .publicationDate(LocalDate.now())
+                .description("세계문화전집 233")
+                .contents("책소개")
+                .coverImageUrl("이미지")
+                .isbn(209348025732L)
+                .build();
+
+        bookRepository.save(requestDto.toEntity());
+        
+        // When
+        Book actual = bookRepository.findById(32L).orElseThrow(IllegalArgumentException::new);
+
+        // Then
+        assertEquals(expectedTitle, actual.getTitle());
+
+    }
+
+    @Test
+    public void isbn_중복_여부_확인_테스트() {
+        // Given
+        Long isbn = 9788937460050L;
+
+        // When
+        Book book = bookRepository.findByIsbn(isbn);
+
+        // Then
+        assertNotNull(book);
+    }
+
+    @Test
+    public void 도서_조회_성공_존재하는_id_입력() {
+        // Given
+        Long id = 1L;
+        String expectedTitle = "동물농장";
+
+        // When
+        Book actual = bookRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+
+        // Then
+        assertEquals(expectedTitle, actual.getTitle());
+    }
+
+    @Test
+    public void 도서_조회_실패_존재하지_않는_id_입력() {
+        // Given
+
+        // When
+        Optional<Book> actual = bookRepository.findById(12L);
+
+        // Then
+        assertFalse(actual.isPresent());
+    }
+
+    @Test
+    public void 도서_수정_성공() {
+        // Given
+        Long id = 3L;
+        String expectedTitle = "속죄";
+        BookRequestDto requestDto = BookRequestDto.builder()
+                .title(expectedTitle)
+                .author("이언 매큐언")
+                .build();
+
+        Book book = bookRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+
+        book.update(requestDto);
+        bookRepository.save(book);
+
+        // When
+        Book actual = bookRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+
+        // Then
+        assertEquals(expectedTitle, actual.getTitle());
+    }
+
+    @Test
+    public void 도서_삭제_성공() {
+        // Given
+        Long id = 5L;
+        Book book = bookRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        bookRepository.delete(book);
+        // When
+
+        Book actual = bookRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+
+        // Then
+        assertEquals(null, actual);
+    }
+
+    @Test
+    public void 도서_검색_성공() {
+        // Given
+        String keyword = "조지";
+        int expectedSize = 7;
+
+        // When
+        List<Book> findBooks = bookRepository.findByKeyword(keyword);
+
+        // Then
+        assertEquals(expectedSize, findBooks.size());
+    }
+
+    @Test
+    public void 도서_신간_조회_성공() {
+        // Given
+        int expectedSize = 7;
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusMonths(1);
+
+        // When
+        List<Book> findBooks = bookRepository.findByNewBooks(startDate, endDate);
+
+        // Then
+        assertEquals(expectedSize, findBooks.size());
+    }
+
+
+
+}


### PR DESCRIPTION
**전체 구현 내용**

도서 상품 관련 API 구현

**상세 구현 내용**

- 도서 관련 CRUD 구현
- 도서 등록시 고유번호인 isbn 중복 확인 후 등록 로직 구현

: 사용자가 이미 존재하는 isbn번호를 등록 요청하여 등록시 예외가 발생하기 전에 중복 확인을 해서 예외를 차단

- 중복된 isbn일 경우 Custom Exception 정의하여 예외처리
- 신간 도서 조회시 오늘 날짜를 기준으로 30일 전에 출판한 도서만 적용되게 구현
- 도서 검색시 요청한 키워드가 제목,작가,역자 중 하나라도 포함이 된 데이터 조회하는 기능 구현
- @RestControllerAdvice와 @ExceptionHandler를 통해 발생하는 예외들을 한 곳에서 처리
- Json 응답 포맷 커스텀하는 클래스 구현

**이슈**

- Jpa에 의존적인 도서 수정 로직

해결책 
: 수정로직을 구현시 Entity 필드 변경을 통해 수정하려 했으나, 이러면 service의 코드가 Jpa에 의존적인 코드가 되기떄문에 MpaRepository에서는 수정을 할 수 없어서 Entity 필드 변경 후 다시 save()메소드 호출을 함. 

- MapRepository사용시 entity id값 저장에대한 고민

해결책 
:MapRepository에서 데이터 등록시 Entity id필드에 값을 저장해야해서 setter메서드를 추가함

- 데이터 응답시 요청마다 필요한 데이터가 달라서 dto를 추가에 관한 고민

해결책 
: 필요치 않는 데이터까지 함께 보내는 것보단 필요한 데이터만 응답하는 게 더 낫다는 판단이 들어 응답에 따른 dto를 추가  

**다음 고도화 계획**

- 카테고리 기능 추가